### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "league/construct-finder": "dev-main as 1.4",
         "robertbaelde/attribute-finder": "^0.2.0",
         "eventsauce/backoff": "^1.2",
-        "laravel/framework": "^11.21 || ^12.0"
+        "laravel/framework": "^11.21 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
## Summary
- Widen `laravel/framework` version constraint from `^11.21 || ^12.0` to `^11.21 || ^12.0 || ^13.0`

## Test plan
- [ ] Verify package installs correctly with Laravel 13
- [ ] Run existing test suite against Laravel 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)