### PR TITLE
Add visibilityDelayMs to all-stream subscriptions

### DIFF
--- a/core/src/Projections/Projector.php
+++ b/core/src/Projections/Projector.php
@@ -14,6 +14,6 @@ class Projector
         public FailureMode $failureMode = FailureMode::Halt,
         public int $startFrom = 0,
         public ?string $name = null,
-        public int $visibilityDelaySeconds = 0,
+        public int $visibilityDelayMs = 0,
     ) {}
 }

--- a/core/src/Projections/Projector.php
+++ b/core/src/Projections/Projector.php
@@ -14,5 +14,6 @@ class Projector
         public FailureMode $failureMode = FailureMode::Halt,
         public int $startFrom = 0,
         public ?string $name = null,
+        public int $visibilityDelaySeconds = 0,
     ) {}
 }

--- a/core/src/Projections/ProjectorConfig.php
+++ b/core/src/Projections/ProjectorConfig.php
@@ -23,7 +23,7 @@ final readonly class ProjectorConfig implements SerializablePayload
         public FailureMode $failureMode = FailureMode::Halt,
         public int $startFrom = 0,
         public ?string $name = null,
-        public int $visibilityDelaySeconds = 0,
+        public int $visibilityDelayMs = 0,
     ) {}
 
     public function toPayload(): array
@@ -39,7 +39,7 @@ final readonly class ProjectorConfig implements SerializablePayload
             'failureMode' => $this->failureMode->value,
             'startFrom' => $this->startFrom,
             'name' => $this->name,
-            'visibilityDelaySeconds' => $this->visibilityDelaySeconds,
+            'visibilityDelayMs' => $this->visibilityDelayMs,
         ];
     }
 
@@ -56,7 +56,7 @@ final readonly class ProjectorConfig implements SerializablePayload
             failureMode: FailureMode::from($payload['failureMode'] ?? FailureMode::Halt->value),
             startFrom: $payload['startFrom'] ?? 0,
             name: $payload['name'] ?? null,
-            visibilityDelaySeconds: $payload['visibilityDelaySeconds'] ?? 0,
+            visibilityDelayMs: $payload['visibilityDelayMs'] ?? 0,
         );
     }
 }

--- a/core/src/Projections/ProjectorConfig.php
+++ b/core/src/Projections/ProjectorConfig.php
@@ -23,6 +23,7 @@ final readonly class ProjectorConfig implements SerializablePayload
         public FailureMode $failureMode = FailureMode::Halt,
         public int $startFrom = 0,
         public ?string $name = null,
+        public int $visibilityDelaySeconds = 0,
     ) {}
 
     public function toPayload(): array
@@ -38,6 +39,7 @@ final readonly class ProjectorConfig implements SerializablePayload
             'failureMode' => $this->failureMode->value,
             'startFrom' => $this->startFrom,
             'name' => $this->name,
+            'visibilityDelaySeconds' => $this->visibilityDelaySeconds,
         ];
     }
 
@@ -54,6 +56,7 @@ final readonly class ProjectorConfig implements SerializablePayload
             failureMode: FailureMode::from($payload['failureMode'] ?? FailureMode::Halt->value),
             startFrom: $payload['startFrom'] ?? 0,
             name: $payload['name'] ?? null,
+            visibilityDelaySeconds: $payload['visibilityDelaySeconds'] ?? 0,
         );
     }
 }

--- a/core/src/Projections/ProjectorMapBuilder.php
+++ b/core/src/Projections/ProjectorMapBuilder.php
@@ -39,6 +39,7 @@ final readonly class ProjectorMapBuilder
                     failureMode: $projectionAttribute->failureMode,
                     startFrom: $projectionAttribute->startFrom,
                     name: $projectionAttribute->name,
+                    visibilityDelaySeconds: $projectionAttribute->visibilityDelaySeconds,
                 ),
                 AggregateProjector::class => new ProjectorConfig(
                     projectorClass: $projectorClass,

--- a/core/src/Projections/ProjectorMapBuilder.php
+++ b/core/src/Projections/ProjectorMapBuilder.php
@@ -39,7 +39,7 @@ final readonly class ProjectorMapBuilder
                     failureMode: $projectionAttribute->failureMode,
                     startFrom: $projectionAttribute->startFrom,
                     name: $projectionAttribute->name,
-                    visibilityDelaySeconds: $projectionAttribute->visibilityDelaySeconds,
+                    visibilityDelayMs: $projectionAttribute->visibilityDelayMs,
                 ),
                 AggregateProjector::class => new ProjectorConfig(
                     projectorClass: $projectorClass,

--- a/core/src/Subscriptions/AllStream/AllStreamSubscription.php
+++ b/core/src/Subscriptions/AllStream/AllStreamSubscription.php
@@ -88,12 +88,19 @@ final readonly class AllStreamSubscription
             $checkpoint = new Checkpoints\Checkpoint($this->subscriptionId, $this->streamOptions->startingFromPosition);
         }
 
-        $maxPosition = $this->eventReader->maxEventId();
+        // For the empty-poll checkpoint advance below: when a visibility delay
+        // is configured, we MUST NOT advance past positions that haven't yet
+        // cleared the delay window — otherwise we'd re-introduce the gap bug
+        // we're trying to prevent. With no delay, this is the global head.
+        $maxPosition = $this->streamOptions->visibilityDelaySeconds > 0
+            ? $this->eventReader->maxEventIdWithVisibilityDelay($this->streamOptions->visibilityDelaySeconds)
+            : $this->eventReader->maxEventId();
 
         $this->appendToActivity($log, 'loading_events', 'loading events', [
             'fromPosition' =>  $checkpoint->position,
             'limit' =>  $this->streamOptions->pageSize,
             'eventTypes' =>  $this->streamOptions->eventTypes,
+            'visibilityDelaySeconds' => $this->streamOptions->visibilityDelaySeconds,
             'time' => time(),
             'run_time' => time() - $startTime,
         ]);
@@ -105,6 +112,7 @@ final readonly class AllStreamSubscription
                 fromPosition: $checkpoint->position,
                 limit: $processBatches ? $this->messageConsumer->getBatchSize() : $this->streamOptions->pageSize,
                 eventTypes: $this->streamOptions->eventTypes,
+                visibilityDelaySeconds: $this->streamOptions->visibilityDelaySeconds,
             ),
         );
 

--- a/core/src/Subscriptions/AllStream/AllStreamSubscription.php
+++ b/core/src/Subscriptions/AllStream/AllStreamSubscription.php
@@ -92,15 +92,15 @@ final readonly class AllStreamSubscription
         // is configured, we MUST NOT advance past positions that haven't yet
         // cleared the delay window — otherwise we'd re-introduce the gap bug
         // we're trying to prevent. With no delay, this is the global head.
-        $maxPosition = $this->streamOptions->visibilityDelaySeconds > 0
-            ? $this->eventReader->maxEventIdWithVisibilityDelay($this->streamOptions->visibilityDelaySeconds)
+        $maxPosition = $this->streamOptions->visibilityDelayMs > 0
+            ? $this->eventReader->maxEventIdWithVisibilityDelay($this->streamOptions->visibilityDelayMs)
             : $this->eventReader->maxEventId();
 
         $this->appendToActivity($log, 'loading_events', 'loading events', [
             'fromPosition' =>  $checkpoint->position,
             'limit' =>  $this->streamOptions->pageSize,
             'eventTypes' =>  $this->streamOptions->eventTypes,
-            'visibilityDelaySeconds' => $this->streamOptions->visibilityDelaySeconds,
+            'visibilityDelayMs' => $this->streamOptions->visibilityDelayMs,
             'time' => time(),
             'run_time' => time() - $startTime,
         ]);
@@ -112,7 +112,7 @@ final readonly class AllStreamSubscription
                 fromPosition: $checkpoint->position,
                 limit: $processBatches ? $this->messageConsumer->getBatchSize() : $this->streamOptions->pageSize,
                 eventTypes: $this->streamOptions->eventTypes,
-                visibilityDelaySeconds: $this->streamOptions->visibilityDelaySeconds,
+                visibilityDelayMs: $this->streamOptions->visibilityDelayMs,
             ),
         );
 

--- a/core/src/Subscriptions/Infra/SubscriptionRegistryFactory.php
+++ b/core/src/Subscriptions/Infra/SubscriptionRegistryFactory.php
@@ -93,6 +93,7 @@ final readonly class SubscriptionRegistryFactory
                 processTimeoutInSeconds: config('saucy.all_stream_projection.timeout'), // @phpstan-ignore-line
                 keepProcessingWithoutNewMessagesBeforeStopInSeconds: config('saucy.all_stream_projection.keep_processing_without_new_messages_before_stop_in_seconds'), // @phpstan-ignore-line
                 queue: config('saucy.all_stream_projection.queue'), // @phpstan-ignore-line
+                visibilityDelaySeconds: $projectorConfig->visibilityDelaySeconds,
             ),
             messageConsumer: $application->make($projectorConfig->projectorClass),
             eventReader: $application->make(AllStreamReader::class),

--- a/core/src/Subscriptions/Infra/SubscriptionRegistryFactory.php
+++ b/core/src/Subscriptions/Infra/SubscriptionRegistryFactory.php
@@ -93,7 +93,7 @@ final readonly class SubscriptionRegistryFactory
                 processTimeoutInSeconds: config('saucy.all_stream_projection.timeout'), // @phpstan-ignore-line
                 keepProcessingWithoutNewMessagesBeforeStopInSeconds: config('saucy.all_stream_projection.keep_processing_without_new_messages_before_stop_in_seconds'), // @phpstan-ignore-line
                 queue: config('saucy.all_stream_projection.queue'), // @phpstan-ignore-line
-                visibilityDelaySeconds: $projectorConfig->visibilityDelaySeconds,
+                visibilityDelayMs: $projectorConfig->visibilityDelayMs,
             ),
             messageConsumer: $application->make($projectorConfig->projectorClass),
             eventReader: $application->make(AllStreamReader::class),

--- a/core/src/Subscriptions/StreamOptions.php
+++ b/core/src/Subscriptions/StreamOptions.php
@@ -8,6 +8,17 @@ final readonly class StreamOptions
 {
     /**
      * @param array<string>|null $eventTypes
+     * @param int $visibilityDelaySeconds When > 0, the all-stream subscription
+     *        will only deliver events whose `created_at` is older than this
+     *        many seconds, and will only advance the empty-poll checkpoint
+     *        to a position whose row passes the same filter. This is the
+     *        guard against the auto-increment commit-order gap: an in-flight
+     *        transaction can reserve a global_position that becomes visible
+     *        well after a poll has already advanced past it. Recommended for
+     *        all-stream subscriptions feeding any side-effect or fact table
+     *        where missed events matter. 1–5 seconds is usually enough; pick
+     *        a value that comfortably exceeds your worst-case insert commit
+     *        latency.
      */
     public function __construct(
         public int $pageSize = 100,
@@ -18,5 +29,6 @@ final readonly class StreamOptions
         public int $keepProcessingWithoutNewMessagesBeforeStopInSeconds = 5,
         public int $sleepWhenNoNewMessagesBeforeRetryInMicroseconds = 500_000, // 0.5 sec default
         public ?string $queue = null,
+        public int $visibilityDelaySeconds = 0,
     ) {}
 }

--- a/core/src/Subscriptions/StreamOptions.php
+++ b/core/src/Subscriptions/StreamOptions.php
@@ -8,17 +8,19 @@ final readonly class StreamOptions
 {
     /**
      * @param array<string>|null $eventTypes
-     * @param int $visibilityDelaySeconds When > 0, the all-stream subscription
+     * @param int $visibilityDelayMs When > 0, the all-stream subscription
      *        will only deliver events whose `created_at` is older than this
-     *        many seconds, and will only advance the empty-poll checkpoint
-     *        to a position whose row passes the same filter. This is the
-     *        guard against the auto-increment commit-order gap: an in-flight
-     *        transaction can reserve a global_position that becomes visible
-     *        well after a poll has already advanced past it. Recommended for
-     *        all-stream subscriptions feeding any side-effect or fact table
-     *        where missed events matter. 1–5 seconds is usually enough; pick
-     *        a value that comfortably exceeds your worst-case insert commit
-     *        latency.
+     *        many milliseconds, and will only advance the empty-poll
+     *        checkpoint to a position whose row passes the same filter.
+     *        This is the guard against the auto-increment commit-order gap:
+     *        an in-flight transaction can reserve a global_position that
+     *        becomes visible well after a poll has already advanced past
+     *        it. Recommended for all-stream subscriptions feeding any
+     *        side-effect or fact table where missed events matter. Typical
+     *        values: 500–5000ms — pick a value that comfortably exceeds
+     *        your worst-case insert commit latency. Requires `created_at`
+     *        to have at least millisecond precision (see migration
+     *        `0000_00_00_000011_bump_event_store_created_at_precision`).
      */
     public function __construct(
         public int $pageSize = 100,
@@ -29,6 +31,6 @@ final readonly class StreamOptions
         public int $keepProcessingWithoutNewMessagesBeforeStopInSeconds = 5,
         public int $sleepWhenNoNewMessagesBeforeRetryInMicroseconds = 500_000, // 0.5 sec default
         public ?string $queue = null,
-        public int $visibilityDelaySeconds = 0,
+        public int $visibilityDelayMs = 0,
     ) {}
 }

--- a/messageStorage/src/AllStreamQuery.php
+++ b/messageStorage/src/AllStreamQuery.php
@@ -8,15 +8,16 @@ final readonly class AllStreamQuery
      * @param int $fromPosition
      * @param int $limit
      * @param array<string>|null $eventTypes
-     * @param int $visibilityDelaySeconds Only return events whose `created_at`
-     *        is older than this many seconds. Defaults to 0 for backwards
-     *        compatibility. Set > 0 to avoid the auto-increment commit-order
-     *        gap (see `IlluminateMessageStorage::paginate` for details).
+     * @param int $visibilityDelayMs Only return events whose `created_at`
+     *        is older than this many milliseconds. Defaults to 0 for
+     *        backwards compatibility. Set > 0 to avoid the auto-increment
+     *        commit-order gap (see `IlluminateMessageStorage::paginate`
+     *        for details).
      */
     public function __construct(
         public int $fromPosition,
         public int $limit,
         public ?array $eventTypes = [],
-        public int $visibilityDelaySeconds = 0,
+        public int $visibilityDelayMs = 0,
     ) {}
 }

--- a/messageStorage/src/AllStreamQuery.php
+++ b/messageStorage/src/AllStreamQuery.php
@@ -8,10 +8,15 @@ final readonly class AllStreamQuery
      * @param int $fromPosition
      * @param int $limit
      * @param array<string>|null $eventTypes
+     * @param int $visibilityDelaySeconds Only return events whose `created_at`
+     *        is older than this many seconds. Defaults to 0 for backwards
+     *        compatibility. Set > 0 to avoid the auto-increment commit-order
+     *        gap (see `IlluminateMessageStorage::paginate` for details).
      */
     public function __construct(
         public int $fromPosition,
         public int $limit,
         public ?array $eventTypes = [],
+        public int $visibilityDelaySeconds = 0,
     ) {}
 }

--- a/messageStorage/src/AllStreamReader.php
+++ b/messageStorage/src/AllStreamReader.php
@@ -12,4 +12,14 @@ interface AllStreamReader
     public function paginate(AllStreamQuery $streamQuery): Generator;
 
     public function maxEventId(): int;
+
+    /**
+     * Returns the highest global_position whose row was inserted at least
+     * `$visibilityDelaySeconds` ago — i.e. the highest position guaranteed
+     * to be safely past the auto-increment commit-order gap. Used by the
+     * all-stream subscription to bound checkpoint advancement on empty polls.
+     *
+     * Returns 0 when no rows pass the filter.
+     */
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int;
 }

--- a/messageStorage/src/AllStreamReader.php
+++ b/messageStorage/src/AllStreamReader.php
@@ -15,11 +15,12 @@ interface AllStreamReader
 
     /**
      * Returns the highest global_position whose row was inserted at least
-     * `$visibilityDelaySeconds` ago — i.e. the highest position guaranteed
-     * to be safely past the auto-increment commit-order gap. Used by the
-     * all-stream subscription to bound checkpoint advancement on empty polls.
+     * `$visibilityDelayMs` milliseconds ago — i.e. the highest position
+     * guaranteed to be safely past the auto-increment commit-order gap.
+     * Used by the all-stream subscription to bound checkpoint advancement
+     * on empty polls.
      *
      * Returns 0 when no rows pass the filter.
      */
-    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int;
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelayMs): int;
 }

--- a/messageStorage/src/HooksMessageStore.php
+++ b/messageStorage/src/HooksMessageStore.php
@@ -35,8 +35,8 @@ final readonly class HooksMessageStore implements AllStreamMessageRepository, Al
         return $this->inner->maxEventId();
     }
 
-    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelayMs): int
     {
-        return $this->inner->maxEventIdWithVisibilityDelay($visibilityDelaySeconds);
+        return $this->inner->maxEventIdWithVisibilityDelay($visibilityDelayMs);
     }
 }

--- a/messageStorage/src/HooksMessageStore.php
+++ b/messageStorage/src/HooksMessageStore.php
@@ -34,4 +34,9 @@ final readonly class HooksMessageStore implements AllStreamMessageRepository, Al
     {
         return $this->inner->maxEventId();
     }
+
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int
+    {
+        return $this->inner->maxEventIdWithVisibilityDelay($visibilityDelaySeconds);
+    }
 }

--- a/messageStorage/src/IlluminateMessageStorage.php
+++ b/messageStorage/src/IlluminateMessageStorage.php
@@ -28,9 +28,13 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
         $streamNameType = $this->streamNameTypeMap->instanceToType($streamName);
         $streamType = $streamName->type();
         $streamName = $streamName->toString();
+        // Format with millisecond precision so visibility-delay filtering
+        // works correctly at sub-second granularity. Requires the column
+        // to be DATETIME(3) or higher — see migration 0000_00_00_000011.
+        $createdAt = now()->format('Y-m-d H:i:s.v');
         $this->connection->table($this->tableName)->insert(
             array_map(
-                function (StreamEvent $event) use ($streamName, $streamNameType, $streamType) {
+                function (StreamEvent $event) use ($streamName, $streamNameType, $streamType, $createdAt) {
                     $serializationResult = $this->eventSerializer->serialize($event->payload);
                     return [
                         'message_id' => $event->eventId,
@@ -41,7 +45,7 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
                         'stream_position' => $event->position,
                         'payload' => $serializationResult->payload,
                         'metadata' => json_encode($event->metadata), // move this to serializer as well?
-                        'created_at' => now(),
+                        'created_at' => $createdAt,
                     ];
                 },
                 $events,
@@ -64,7 +68,7 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
     /**
      * @return Generator<int, StoredEvent>
      *
-     * `visibilityDelaySeconds` guards against the auto-increment commit-order
+     * `visibilityDelayMs` guards against the auto-increment commit-order
      * gap: MySQL reserves auto-increment values at INSERT time but rows only
      * become visible at COMMIT. Under concurrent writers, an INSERT that
      * reserves position N can commit *after* a later position N+M is already
@@ -74,6 +78,9 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
      * out the worst-case commit window so any in-flight gap below the
      * horizon has had time to either commit (and become visible to us) or
      * roll back (and stay invisible forever).
+     *
+     * Sub-second values require `event_store.created_at` to have at least
+     * millisecond precision (DATETIME(3) on MySQL).
      */
     public function paginate(AllStreamQuery $streamQuery): Generator
     {
@@ -83,8 +90,8 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
             ->when($streamQuery->eventTypes !== null, function ($query) use ($streamQuery) {
                 return $query->whereIn('message_type', $streamQuery->eventTypes);
             })
-            ->when($streamQuery->visibilityDelaySeconds > 0, function ($query) use ($streamQuery) {
-                return $query->where('created_at', '<', now('UTC')->subSeconds($streamQuery->visibilityDelaySeconds)->toDateTimeString());
+            ->when($streamQuery->visibilityDelayMs > 0, function ($query) use ($streamQuery) {
+                return $query->where('created_at', '<', $this->visibilityHorizon($streamQuery->visibilityDelayMs));
             })
             ->limit($streamQuery->limit)
             ->orderBy('global_position')
@@ -92,17 +99,22 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
         );
     }
 
-    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelayMs): int
     {
-        if ($visibilityDelaySeconds <= 0) {
+        if ($visibilityDelayMs <= 0) {
             return $this->maxEventId();
         }
 
         $max = $this->connection->table($this->tableName)
-            ->where('created_at', '<', now('UTC')->subSeconds($visibilityDelaySeconds)->toDateTimeString())
+            ->where('created_at', '<', $this->visibilityHorizon($visibilityDelayMs))
             ->max('global_position');
 
         return $max === null ? 0 : (int) $max;
+    }
+
+    private function visibilityHorizon(int $visibilityDelayMs): string
+    {
+        return now('UTC')->subMilliseconds($visibilityDelayMs)->format('Y-m-d H:i:s.v');
     }
 
     /**

--- a/messageStorage/src/IlluminateMessageStorage.php
+++ b/messageStorage/src/IlluminateMessageStorage.php
@@ -63,6 +63,17 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
 
     /**
      * @return Generator<int, StoredEvent>
+     *
+     * `visibilityDelaySeconds` guards against the auto-increment commit-order
+     * gap: MySQL reserves auto-increment values at INSERT time but rows only
+     * become visible at COMMIT. Under concurrent writers, an INSERT that
+     * reserves position N can commit *after* a later position N+M is already
+     * visible — without the filter, a poll between the two commits would
+     * advance the checkpoint past N+M and then never deliver N when it
+     * eventually commits. Filtering by `created_at < NOW() - delay` waits
+     * out the worst-case commit window so any in-flight gap below the
+     * horizon has had time to either commit (and become visible to us) or
+     * roll back (and stay invisible forever).
      */
     public function paginate(AllStreamQuery $streamQuery): Generator
     {
@@ -72,10 +83,26 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
             ->when($streamQuery->eventTypes !== null, function ($query) use ($streamQuery) {
                 return $query->whereIn('message_type', $streamQuery->eventTypes);
             })
+            ->when($streamQuery->visibilityDelaySeconds > 0, function ($query) use ($streamQuery) {
+                return $query->where('created_at', '<', now('UTC')->subSeconds($streamQuery->visibilityDelaySeconds)->toDateTimeString());
+            })
             ->limit($streamQuery->limit)
             ->orderBy('global_position')
             ->cursor(),
         );
+    }
+
+    public function maxEventIdWithVisibilityDelay(int $visibilityDelaySeconds): int
+    {
+        if ($visibilityDelaySeconds <= 0) {
+            return $this->maxEventId();
+        }
+
+        $max = $this->connection->table($this->tableName)
+            ->where('created_at', '<', now('UTC')->subSeconds($visibilityDelaySeconds)->toDateTimeString())
+            ->max('global_position');
+
+        return $max === null ? 0 : (int) $max;
     }
 
     /**

--- a/migrations/0000_00_00_000000_create_event_store_table.php
+++ b/migrations/0000_00_00_000000_create_event_store_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->unsignedInteger('stream_position');
             $table->json('payload');
             $table->json('metadata')->nullable();
-            $table->dateTime('created_at');
+            $table->dateTime('created_at', 3);
 
             $table->unique(['stream_name', 'message_id'], 'idempotency_index');
             $table->unique(['stream_name', 'stream_position'], 'optimistic_lock_index');

--- a/migrations/0000_00_00_000011_bump_event_store_created_at_precision.php
+++ b/migrations/0000_00_00_000011_bump_event_store_created_at_precision.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Bumps `event_store.created_at` from DATETIME (second precision) to
+ * DATETIME(3) (millisecond precision) so the visibility-delay filter
+ * works at sub-second granularity.
+ *
+ * Online DDL on MySQL 8 / InnoDB — INSTANT for adding fractional
+ * precision; no table copy. Existing rows are padded with `.000`.
+ *
+ * On PlanetScale / Vitess this is also non-blocking.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('event_store', function (Blueprint $table) {
+            $table->dateTime('created_at', 3)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('event_store', function (Blueprint $table) {
+            $table->dateTime('created_at')->change();
+        });
+    }
+};

--- a/workbench/tests/AllStreamVisibilityDelayTest.php
+++ b/workbench/tests/AllStreamVisibilityDelayTest.php
@@ -18,7 +18,7 @@ use Workbench\App\BankAccount\Events\AccountCredited;
  * already advanced past N+1, permanently stranding N below the checkpoint.
  *
  * The fix is to only return rows whose `created_at` is older than
- * `visibilityDelaySeconds`, giving any in-flight commit time to settle.
+ * `visibilityDelayMs`, giving any in-flight commit time to settle.
  */
 final class AllStreamVisibilityDelayTest extends WithDatabaseTestCase
 {
@@ -28,14 +28,14 @@ final class AllStreamVisibilityDelayTest extends WithDatabaseTestCase
         $reader = $this->buildReader();
 
         // Two rows: one well in the past, one just now.
-        $this->insertEventAt('past', '2020-01-01 00:00:00');
-        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+        $this->insertEventAt('past', '2020-01-01 00:00:00.000');
+        $this->insertEventAt('recent', now('UTC')->format('Y-m-d H:i:s.v'));
 
         $withoutDelay = iterator_to_array($reader->paginate(new AllStreamQuery(
             fromPosition: 0,
             limit: 10,
             eventTypes: null,
-            visibilityDelaySeconds: 0,
+            visibilityDelayMs: 0,
         )));
         $this->assertCount(2, $withoutDelay, 'baseline: no delay returns both rows');
 
@@ -43,10 +43,37 @@ final class AllStreamVisibilityDelayTest extends WithDatabaseTestCase
             fromPosition: 0,
             limit: 10,
             eventTypes: null,
-            visibilityDelaySeconds: 30,
+            visibilityDelayMs: 30_000,
         )));
         $this->assertCount(1, $withDelay, 'with 30s delay only the past row is returned');
         $this->assertSame('past', $withDelay[0]->streamName);
+    }
+
+    /** @test */
+    public function sub_second_delay_filters_recent_rows_at_millisecond_precision(): void
+    {
+        $reader = $this->buildReader();
+
+        // Insert a row 250ms ago. With a 500ms delay it should be filtered;
+        // with a 100ms delay it should pass.
+        $insertedAt = now('UTC')->subMilliseconds(250)->format('Y-m-d H:i:s.v');
+        $this->insertEventAt('recent', $insertedAt);
+
+        $with500ms = iterator_to_array($reader->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 10,
+            eventTypes: null,
+            visibilityDelayMs: 500,
+        )));
+        $this->assertCount(0, $with500ms, 'row inserted 250ms ago is excluded by a 500ms delay');
+
+        $with100ms = iterator_to_array($reader->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 10,
+            eventTypes: null,
+            visibilityDelayMs: 100,
+        )));
+        $this->assertCount(1, $with100ms, 'row inserted 250ms ago is included by a 100ms delay');
     }
 
     /** @test */
@@ -54,22 +81,22 @@ final class AllStreamVisibilityDelayTest extends WithDatabaseTestCase
     {
         $reader = $this->buildReader();
 
-        $this->insertEventAt('past', '2020-01-01 00:00:00');
+        $this->insertEventAt('past', '2020-01-01 00:00:00.000');
         $pastPosition = (int) DB::table('event_store')->where('stream_name', 'past')->value('global_position');
 
-        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+        $this->insertEventAt('recent', now('UTC')->format('Y-m-d H:i:s.v'));
 
         $this->assertGreaterThan($pastPosition, $reader->maxEventId());
-        $this->assertSame($pastPosition, $reader->maxEventIdWithVisibilityDelay(30));
+        $this->assertSame($pastPosition, $reader->maxEventIdWithVisibilityDelay(30_000));
     }
 
     /** @test */
     public function max_event_id_with_visibility_delay_returns_zero_when_no_rows_pass_the_filter(): void
     {
         $reader = $this->buildReader();
-        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+        $this->insertEventAt('recent', now('UTC')->format('Y-m-d H:i:s.v'));
 
-        $this->assertSame(0, $reader->maxEventIdWithVisibilityDelay(30));
+        $this->assertSame(0, $reader->maxEventIdWithVisibilityDelay(30_000));
     }
 
     private function buildReader(): AllStreamReader

--- a/workbench/tests/AllStreamVisibilityDelayTest.php
+++ b/workbench/tests/AllStreamVisibilityDelayTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Workbench\Tests;
+
+use Illuminate\Support\Facades\DB;
+use Saucy\Core\Serialisation\TypeMap;
+use Saucy\MessageStorage\AllStreamQuery;
+use Saucy\MessageStorage\AllStreamReader;
+use Saucy\MessageStorage\IlluminateMessageStorage;
+use Saucy\MessageStorage\Serialization\ConstructingPayloadSerializer;
+use Workbench\App\BankAccount\Events\AccountCredited;
+
+/**
+ * Guards the visibility-delay filter that protects against the auto-increment
+ * commit-order gap. The bug it prevents: MySQL reserves auto-increment values
+ * at INSERT time but rows only become visible at COMMIT — under concurrent
+ * writers, an in-flight commit at position N can land *after* a poll has
+ * already advanced past N+1, permanently stranding N below the checkpoint.
+ *
+ * The fix is to only return rows whose `created_at` is older than
+ * `visibilityDelaySeconds`, giving any in-flight commit time to settle.
+ */
+final class AllStreamVisibilityDelayTest extends WithDatabaseTestCase
+{
+    /** @test */
+    public function paginate_filters_out_recently_inserted_rows_when_visibility_delay_is_set(): void
+    {
+        $reader = $this->buildReader();
+
+        // Two rows: one well in the past, one just now.
+        $this->insertEventAt('past', '2020-01-01 00:00:00');
+        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+
+        $withoutDelay = iterator_to_array($reader->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 10,
+            eventTypes: null,
+            visibilityDelaySeconds: 0,
+        )));
+        $this->assertCount(2, $withoutDelay, 'baseline: no delay returns both rows');
+
+        $withDelay = iterator_to_array($reader->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 10,
+            eventTypes: null,
+            visibilityDelaySeconds: 30,
+        )));
+        $this->assertCount(1, $withDelay, 'with 30s delay only the past row is returned');
+        $this->assertSame('past', $withDelay[0]->streamName);
+    }
+
+    /** @test */
+    public function max_event_id_with_visibility_delay_excludes_recent_rows(): void
+    {
+        $reader = $this->buildReader();
+
+        $this->insertEventAt('past', '2020-01-01 00:00:00');
+        $pastPosition = (int) DB::table('event_store')->where('stream_name', 'past')->value('global_position');
+
+        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+
+        $this->assertGreaterThan($pastPosition, $reader->maxEventId());
+        $this->assertSame($pastPosition, $reader->maxEventIdWithVisibilityDelay(30));
+    }
+
+    /** @test */
+    public function max_event_id_with_visibility_delay_returns_zero_when_no_rows_pass_the_filter(): void
+    {
+        $reader = $this->buildReader();
+        $this->insertEventAt('recent', now('UTC')->toDateTimeString());
+
+        $this->assertSame(0, $reader->maxEventIdWithVisibilityDelay(30));
+    }
+
+    private function buildReader(): AllStreamReader
+    {
+        return new IlluminateMessageStorage(
+            connection: DB::connection(),
+            eventSerializer: new ConstructingPayloadSerializer($this->app->make(TypeMap::class)),
+            streamNameTypeMap: $this->app->make(TypeMap::class),
+        );
+    }
+
+    private function insertEventAt(string $streamName, string $createdAt): void
+    {
+        DB::table('event_store')->insert([
+            'message_id' => bin2hex(random_bytes(13)),
+            'message_type' => (new \ReflectionClass(AccountCredited::class))->getShortName(),
+            'stream_name_type' => 'aggregate_stream_name',
+            'stream_type' => 'bank_account',
+            'stream_name' => $streamName,
+            'stream_position' => 1,
+            'payload' => '{}',
+            'metadata' => '{}',
+            'created_at' => $createdAt,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Pragmatic fix for the auto-increment commit-order race in the all-stream subscription. MySQL reserves \`global_position\` values at INSERT time but only makes rows visible at COMMIT — under concurrent writers, a poll can observe N+1 without ever seeing N, and the checkpoint then advances past the missing position permanently.

This PR adds an opt-in \`visibilityDelayMs\` option to all-stream projectors. When set, \`paginate()\` filters out rows with \`created_at >= NOW() - delay\`, and the empty-poll checkpoint advance is bounded by \`maxEventIdWithVisibilityDelay()\`. Any in-flight commit at a position below the delay horizon gets time to either commit (visible to us) or roll back (invisible forever).

Default is 0 (current behaviour). Enable per projector via \`#[Projector(visibilityDelayMs: N)]\`. Recommended for projectors feeding fact tables or side-effects where missed events matter.

Per-aggregate projectors (\`#[AggregateProjector]\`) are unaffected — they use contiguous code-assigned \`stream_position\` and are gap-immune by construction.

A more sophisticated active gap-detection approach is open in #11 — parking that for now in favour of this smaller change. The two are mutually exclusive; this lands first.

### Why milliseconds (and the new migration)

The unit is milliseconds so sub-second delays like 500ms or 750ms can be expressed naturally — typical write transactions commit in tens-to-hundreds of ms, so a seconds-only knob would overshoot wildly.

To make sub-second filtering work, \`event_store.created_at\` needs millisecond precision. Migration \`0000_00_00_000011_bump_event_store_created_at_precision\` ALTERs the column to DATETIME(3). This is online DDL on MySQL 8 / InnoDB (INSTANT for precision add, no table copy) and on PlanetScale. Existing rows get padded with \`.000\`.

\`IlluminateMessageStorage::persist()\` formats new rows with \`Y-m-d H:i:s.v\`. The filter horizon is computed via \`Carbon::subMilliseconds()\`.

## Picking a value for \`visibilityDelayMs\`

The delay needs to comfortably exceed your worst-case write-transaction duration. Run this on PlanetScale during peak load to see how long transactions actually stay open:

\`\`\`sql
-- Live snapshot of currently-running transactions, longest first.
-- Run several times during your peak window and capture the max duration_ms.
SELECT
    trx_id,
    trx_state,
    trx_started,
    TIMESTAMPDIFF(MICROSECOND, trx_started, NOW(6)) / 1000 AS duration_ms,
    trx_rows_modified,
    LEFT(trx_query, 100) AS query_preview
FROM information_schema.innodb_trx
WHERE trx_state = 'RUNNING'
ORDER BY duration_ms DESC
LIMIT 20;
\`\`\`

If max observed is e.g. 200ms across many samples, set \`visibilityDelayMs: 1000\` (5x safety margin). PlanetScale's Insights dashboard also surfaces transaction durations if you'd rather use the UI.

Rule of thumb: start with **500–1000ms for most projectors**, bump to 2000–5000ms only if you see long-running batch transactions in the data.

## Test plan

- [x] \`AllStreamVisibilityDelayTest\` — 4 tests: paginate filters recent rows at second granularity, paginate filters at millisecond granularity (250ms-old row vs 500ms/100ms delay), \`maxEventIdWithVisibilityDelay\` excludes recent rows, returns 0 when no rows pass.
- [x] PHPStan: no regressions (71 errors, same as baseline area).
- [x] php-cs-fixer: clean.
- [ ] Run the PlanetScale query during peak load to pick a real value.
- [ ] Deploy migration \`0000_00_00_000011\` (online DDL, non-blocking) before bumping any projector's \`visibilityDelayMs\` above 0.
- [ ] Apply to the bulk projector that was losing events; monitor for missed-event recurrence over a peak day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)