### PR TITLE
fix(message-storage): defer payload fetch in all-stream paginate to avoid sort-buffer exhaustion

### DIFF
--- a/messageStorage/src/IlluminateMessageStorage.php
+++ b/messageStorage/src/IlluminateMessageStorage.php
@@ -66,15 +66,37 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
      */
     public function paginate(AllStreamQuery $streamQuery): Generator
     {
-        return $this->mapRowsToStoredEvents(
-            $this->connection->table($this->tableName)
+        // Resolve the matching global positions first, selecting only the indexed
+        // `global_position` column. This keeps the `(message_type, global_position)`
+        // index covering, so the `ORDER BY global_position ... LIMIT` is satisfied by a
+        // narrow sort over 8-byte integers.
+        //
+        // Selecting whole rows here (the previous `SELECT *`) forces MySQL 8 to
+        // filesort the full rows — including the large `payload`/`metadata` JSON
+        // columns — because a `message_type IN (...)` filter spans multiple index
+        // ranges that can no longer feed the `ORDER BY` directly. With wide JSON
+        // payloads that sort can exhaust `sort_buffer_size` and fail with
+        // ER_OUT_OF_SORTMEMORY (errno 1038), as seen on PlanetScale/Vitess. Fetching
+        // the rows afterwards by primary key avoids putting the payload in the sort.
+        $positions = $this->connection->table($this->tableName)
             ->where('global_position', '>', $streamQuery->fromPosition)
             ->when($streamQuery->eventTypes !== null, function ($query) use ($streamQuery) {
                 return $query->whereIn('message_type', $streamQuery->eventTypes);
             })
-            ->limit($streamQuery->limit)
             ->orderBy('global_position')
-            ->cursor(),
+            ->limit($streamQuery->limit)
+            ->pluck('global_position')
+            ->all();
+
+        if ($positions === []) {
+            return;
+        }
+
+        yield from $this->mapRowsToStoredEvents(
+            $this->connection->table($this->tableName)
+                ->whereIn('global_position', $positions)
+                ->orderBy('global_position')
+                ->cursor(),
         );
     }
 
@@ -101,7 +123,7 @@ final readonly class IlluminateMessageStorage implements AllStreamMessageReposit
 
     /**
      * @param LazyCollection<int, object> $rows
-     * @return Generator
+     * @return Generator<int, StoredEvent>
      * @throws \Exception
      */
     private function mapRowsToStoredEvents(LazyCollection $rows): Generator

--- a/workbench/tests/IlluminateMessageStoragePaginationTest.php
+++ b/workbench/tests/IlluminateMessageStoragePaginationTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Workbench\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+use Saucy\Core\Serialisation\TypeMap;
+use Saucy\MessageStorage\AllStreamQuery;
+use Saucy\MessageStorage\IlluminateMessageStorage;
+use Saucy\MessageStorage\Serialization\EventSerializer;
+use Saucy\MessageStorage\Serialization\SerializationResult;
+
+/**
+ * Regression coverage for the deferred-fetch pagination in IlluminateMessageStorage::paginate().
+ *
+ * paginate() resolves the matching `global_position` values from the covering index first and only
+ * then fetches the full rows by primary key. This avoids the wide-row filesort that exhausted the
+ * MySQL sort buffer (ER_OUT_OF_SORTMEMORY / errno 1038) when filtering on `message_type IN (...)`
+ * and ordering by `global_position`. These tests pin the externally observable behaviour: correct
+ * filtering, global ordering across interleaved message types, and `fromPosition`/`limit` handling.
+ */
+final class IlluminateMessageStoragePaginationTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('event_store', function (Blueprint $table) {
+            $table->unsignedBigInteger('global_position', true);
+            $table->ulid('message_id');
+            $table->string('message_type');
+            $table->string('stream_name_type');
+            $table->string('stream_type');
+            $table->string('stream_name');
+            $table->unsignedInteger('stream_position');
+            $table->json('payload');
+            $table->json('metadata')->nullable();
+            $table->dateTime('created_at');
+
+            $table->index(['message_type', 'global_position'], 'all_stream_projection_index');
+        });
+    }
+
+    private function storage(): IlluminateMessageStorage
+    {
+        $serializer = new class implements EventSerializer {
+            public function serialize(object $event): SerializationResult
+            {
+                return new SerializationResult($event::class, '{}');
+            }
+
+            public function deserialize(SerializationResult $serializationResult): object
+            {
+                return (object) [];
+            }
+        };
+
+        return new IlluminateMessageStorage(DB::connection(), $serializer, new TypeMap([]));
+    }
+
+    /**
+     * @param array{int, string} ...$events tuples of [global_position, message_type]
+     */
+    private function seedEvents(array ...$events): void
+    {
+        foreach ($events as [$position, $type]) {
+            DB::table('event_store')->insert([
+                'global_position' => $position,
+                'message_id' => str_pad((string) $position, 26, '0', STR_PAD_LEFT),
+                'message_type' => $type,
+                'stream_name_type' => 'order',
+                'stream_type' => 'order',
+                'stream_name' => 'order-' . $position,
+                'stream_position' => 1,
+                // A deliberately large payload mirrors the production rows whose width blew the
+                // sort buffer when they were dragged through a SELECT * filesort.
+                'payload' => json_encode(['blob' => str_repeat('x', 2048)]),
+                'metadata' => json_encode([]),
+                'created_at' => '2026-06-01 00:00:00',
+            ]);
+        }
+    }
+
+    /** @test */
+    public function it_filters_by_event_type_and_returns_results_in_global_position_order(): void
+    {
+        // message types are interleaved across positions; the two we want are not contiguous.
+        $this->seedEvents(
+            [1, 'order.created'],
+            [2, 'order.refunded'],
+            [3, 'order.created_from_cart'],
+            [4, 'order.refunded'],
+            [5, 'order.created'],
+            [6, 'order.created_from_cart'],
+        );
+
+        $events = iterator_to_array($this->storage()->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 500,
+            eventTypes: ['order.created_from_cart', 'order.created'],
+        )));
+
+        $this->assertSame(
+            [1, 3, 5, 6],
+            array_map(static fn($e) => $e->globalPosition, $events),
+            'Events must come back filtered by type and globally ordered by position.',
+        );
+        $this->assertSame(
+            ['order.created', 'order.created_from_cart', 'order.created', 'order.created_from_cart'],
+            array_map(static fn($e) => $e->eventType, $events),
+        );
+    }
+
+    /** @test */
+    public function it_respects_from_position_and_limit(): void
+    {
+        $this->seedEvents(
+            [1, 'order.created'],
+            [2, 'order.created'],
+            [3, 'order.created'],
+            [4, 'order.created'],
+        );
+
+        $events = iterator_to_array($this->storage()->paginate(new AllStreamQuery(
+            fromPosition: 1,
+            limit: 2,
+            eventTypes: ['order.created'],
+        )));
+
+        $this->assertSame([2, 3], array_map(static fn($e) => $e->globalPosition, $events));
+    }
+
+    /** @test */
+    public function it_returns_all_events_when_no_event_types_are_given(): void
+    {
+        $this->seedEvents(
+            [1, 'order.created'],
+            [2, 'order.refunded'],
+            [3, 'order.created_from_cart'],
+        );
+
+        $events = iterator_to_array($this->storage()->paginate(new AllStreamQuery(
+            fromPosition: 0,
+            limit: 500,
+            eventTypes: null,
+        )));
+
+        $this->assertSame([1, 2, 3], array_map(static fn($e) => $e->globalPosition, $events));
+    }
+
+    /** @test */
+    public function it_yields_nothing_when_no_events_match(): void
+    {
+        $this->seedEvents([1, 'order.created']);
+
+        $events = iterator_to_array($this->storage()->paginate(new AllStreamQuery(
+            fromPosition: 10,
+            limit: 500,
+            eventTypes: ['order.created'],
+        )));
+
+        $this->assertSame([], $events);
+    }
+}


### PR DESCRIPTION
## Problem

The all-stream subscription poller (`AllStreamSubscription::poll` → `IlluminateMessageStorage::paginate`) ran:

```sql
SELECT * FROM event_store
WHERE global_position > ? AND message_type IN (?, ?)
ORDER BY global_position ASC
LIMIT ?
```

A multi-value `message_type IN (...)` filter spans several ranges of the `(message_type, global_position)` index, so the index can no longer satisfy the `ORDER BY global_position` directly and MySQL falls back to a **filesort**. Under `SELECT *`, that filesort packs the full rows — including the large `payload`/`metadata` **JSON** columns — into the sort buffer. On MySQL 8 (where wide-row "addon" packing is unconditional) this can exceed `sort_buffer_size` and fail with:

```
SQLSTATE[HY001]: Memory allocation error: 1038 ... Out of sort memory,
consider increasing server sort buffer size (errno 1038)
```

Observed in production on PlanetScale/Vitess, crashing the `vapor:work` poller for the subscription that filters on `order.created` + `order.created_from_cart`.

## Fix

Resolve the matching `global_position` values **first**, selecting only that column. This keeps the `(message_type, global_position)` index covering, so the `ORDER BY ... LIMIT` is a narrow sort over 8-byte integers that can't blow the sort buffer. The full rows are then fetched by primary key, where no sort of the payload is needed.

External behaviour — type filtering, global `global_position` ordering, `fromPosition`/`limit` — is unchanged. When no positions match, an empty generator is returned without issuing the second query.

Also tightened `mapRowsToStoredEvents()`'s `@return` to `Generator<int, StoredEvent>` so the new `yield from` keeps PHPStan at the existing baseline.

## Testing

Added `IlluminateMessageStoragePaginationTest` covering type filtering, global ordering across **interleaved** message types (the regression), `fromPosition`/`limit`, the unfiltered path, and the empty result. The seed rows use deliberately large payloads to mirror the production rows whose width triggered the failure.

```
vendor/bin/phpunit workbench/tests/IlluminateMessageStoragePaginationTest.php
OK (4 tests, 5 assertions)
```

`vendor/bin/phpstan analyse messageStorage/src/IlluminateMessageStorage.php` stays at the pre-existing 6 errors (no new ones); php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)